### PR TITLE
Schema updates

### DIFF
--- a/froggydoro/ios/Podfile.lock
+++ b/froggydoro/ios/Podfile.lock
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  wakelock_plus: 04623e3f525556020ebd4034310f20fe7fda8b49
+  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 
 PODFILE CHECKSUM: 20e260c9bb3f61194c661a4ba028da86e4f3ed96
 

--- a/froggydoro/lib/services/database_service.dart
+++ b/froggydoro/lib/services/database_service.dart
@@ -22,6 +22,18 @@ class DatabaseService {
   final String _calendarEntriesType = 'type';
   final String _calendarEntriesStatus = 'status';
 
+  final String _achievementsTableName = 'achievements';
+  final String _achievementsColumnId = 'achievement_id';
+  final String _achievementsName = 'name';
+  final String _achievementsDescription = 'description';
+  final String _achievementsIconPath = 'path_to_icon';
+  final String _achievementsCriteriaKey = "criteria_key";
+  final String _achievementsCriteriaValue = "criteria_value";
+
+  final String _userAchievementsTableName = 'user_achievements';
+  final String _userAchievementsColumnId = 'user_achievement_id';
+  final String _userAchievementsUnlockDate = 'unlocked_date';
+
   DatabaseService._constructor();
 
   Future<Database> get database async {
@@ -40,7 +52,7 @@ class DatabaseService {
 
     final database = await openDatabase(
       path,
-      version: 4, // Increment the version
+      version: 5, // Increment the version
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE $_timersTableName (
@@ -62,18 +74,48 @@ class DatabaseService {
             $_calendarEntriesStatus TEXT NOT NULL
           )
         ''');
+
+        await db.execute('''
+          CREATE TABLE $_achievementsTableName (
+            $_achievementsColumnId INTEGER PRIMARY KEY AUTOINCREMENT,
+            $_achievementsName TEXT NOT NULL,
+            $_achievementsDescription TEXT NOT NULL,
+            $_achievementsIconPath TEXT,
+            $_achievementsCriteriaKey TEXT NOT NULL,
+            $_achievementsCriteriaValue INTEGER NOT NULL
+          );
+        ''');
+
+        await db.execute('''
+          CREATE TABLE $_userAchievementsTableName (
+            $_userAchievementsColumnId INTEGER PRIMARY KEY AUTOINCREMENT,
+            $_achievementsColumnId INTEGER NOT NULL,
+            $_userAchievementsUnlockDate TEXT NOT NULL,
+            FOREIGN KEY ($_achievementsColumnId) REFERENCES $_achievementsTableName($_achievementsColumnId)
+          );
+        ''');
       },
       onUpgrade: (db, oldVersion, newVersion) async {
-        if (oldVersion < 4) {
+        if (oldVersion < 5) {
           await db.execute('''
-          CREATE TABLE $_calendarEntriesTableName (
-            $_calendarEntriesColumnId INTEGER PRIMARY KEY AUTOINCREMENT,
-            $_calendarEntriesDate TEXT NOT NULL,
-            $_calendarEntriesDuration INTEGER NOT NULL,
-            $_calendarEntriesType TEXT NOT NULL,
-            $_calendarEntriesStatus TEXT NOT NULL
-          )
+          CREATE TABLE $_achievementsTableName (
+            $_achievementsColumnId INTEGER PRIMARY KEY AUTOINCREMENT,
+            $_achievementsName TEXT NOT NULL,
+            $_achievementsDescription TEXT NOT NULL,
+            $_achievementsIconPath TEXT,
+            $_achievementsCriteriaKey TEXT NOT NULL,
+            $_achievementsCriteriaValue INTEGER NOT NULL
+          );
         ''');
+
+          await db.execute('''
+            CREATE TABLE $_userAchievementsTableName (
+              $_userAchievementsColumnId INTEGER PRIMARY KEY AUTOINCREMENT,
+              $_achievementsColumnId INTEGER NOT NULL,
+              $_userAchievementsUnlockDate TEXT NOT NULL,
+              FOREIGN KEY ($_achievementsColumnId) REFERENCES $_achievementsTableName($_achievementsColumnId)
+            );
+          ''');
         }
       },
     );

--- a/froggydoro/lib/services/database_service.dart
+++ b/froggydoro/lib/services/database_service.dart
@@ -15,6 +15,13 @@ class DatabaseService {
   final String _timersColumnCount = 'count';
   final String _timersColumnIsPicked = 'is_picked';
 
+  final String _calendarEntriesTableName = 'calendar_entries';
+  final String _calendarEntriesColumnId = 'entry_id';
+  final String _calendarEntriesDate = 'date';
+  final String _calendarEntriesDuration = 'duration';
+  final String _calendarEntriesType = 'type';
+  final String _calendarEntriesStatus = 'status';
+
   DatabaseService._constructor();
 
   Future<Database> get database async {
@@ -33,7 +40,7 @@ class DatabaseService {
 
     final database = await openDatabase(
       path,
-      version: 3, // Increment the version
+      version: 4, // Increment the version
       onCreate: (db, version) async {
         await db.execute('''
           CREATE TABLE $_timersTableName (
@@ -45,13 +52,28 @@ class DatabaseService {
             $_timersColumnIsPicked INTEGER DEFAULT 0
           )
         ''');
+
+        await db.execute('''
+          CREATE TABLE $_calendarEntriesTableName (
+            $_calendarEntriesColumnId INTEGER PRIMARY KEY AUTOINCREMENT,
+            $_calendarEntriesDate TEXT NOT NULL,
+            $_calendarEntriesDuration INTEGER NOT NULL,
+            $_calendarEntriesType TEXT NOT NULL,
+            $_calendarEntriesStatus TEXT NOT NULL
+          )
+        ''');
       },
       onUpgrade: (db, oldVersion, newVersion) async {
-        if (oldVersion < 3) {
-          // Add the is_picked column if it doesn't exist
-          await db.execute(
-            'ALTER TABLE $_timersTableName ADD COLUMN $_timersColumnIsPicked INTEGER DEFAULT 0',
-          );
+        if (oldVersion < 4) {
+          await db.execute('''
+          CREATE TABLE $_calendarEntriesTableName (
+            $_calendarEntriesColumnId INTEGER PRIMARY KEY AUTOINCREMENT,
+            $_calendarEntriesDate TEXT NOT NULL,
+            $_calendarEntriesDuration INTEGER NOT NULL,
+            $_calendarEntriesType TEXT NOT NULL,
+            $_calendarEntriesStatus TEXT NOT NULL
+          )
+        ''');
         }
       },
     );
@@ -140,7 +162,7 @@ class DatabaseService {
     );
   }
 
-  void deleteTimer(int id) async {
+  Future<void> deleteTimer(int id) async {
     final db = await database;
     await db.delete(
       _timersTableName,


### PR DESCRIPTION
**changes:**
- added new calendar entry table to schema
- added new achievement and user_achievement tables to schema

**how to test:**
- check if the app runs and if the timer preset selection screen works.

**possible faults:**
- current code accepts that the database in the app has a calendar entries table.
- if problem occurs try adding the db.execute of the calendar entries table into the on_upgrade.